### PR TITLE
Ajustes de Layout dos Graficos Comparativos

### DIFF
--- a/app/Http/Controllers/cadastros/manutencao/CacheCompEscolaController.php
+++ b/app/Http/Controllers/cadastros/manutencao/CacheCompEscolaController.php
@@ -52,13 +52,17 @@ class CacheCompEscolaController extends Controller
         $this->previlegio = [];
         $this->horasCache = 4;
         $this->backgroundColors = [
-            'rgba(255, 26, 104, 0.2)', 'rgba(54, 162, 235, 0.2)', 'rgba(255, 206, 86, 0.2)',
-            'rgba(75, 192, 192, 0.2)', 'rgba(153, 102, 255, 0.2)', 'rgba(255, 159, 64, 0.2)', 'rgba(0, 0, 0, 0.2)'
-        ];
+            'rgba(139,0,0, 0.2)','rgba(54, 162, 235, 0.2)','rgba(255, 206, 86, 0.2)','rgba(75, 192, 192, 0.2)','rgba(153, 102, 255, 0.2)',
+            'rgba(255, 159, 64, 0.2)','rgba(0, 0, 0, 0.2)','rgba(220,220,220,0.3)','rgba(0,0,139,0.2)','rgba(160,82,45,0.2)',
+            'rgba(255,0,255,0.2)','rgba(0,128,0,0.2)','rgba(255,255,0,0.2)','rgba(0,0,255,0.2)','rgba(0,255,0,0.2)','rgba(255,255,255,0.2)',
+            'rgba(255,0,0,0.2)','rgba(255,140,0,0.3)','rgba(128,128,0,0.3)','rgba(255,20,147,0.3)','rgba(250,128,114,0.3)','rgba(0,255,0,0.3)',
+            'rgba(255,215,0,0.4)'];
         $this->borderColors = [
-            'rgba(255, 26, 104, 1)', 'rgba(54, 162, 235, 1)', 'rgba(255, 206, 86, 1)',
-            'rgba(75, 192, 192, 1)', 'rgba(153, 102, 255, 1)', 'rgba(255, 159, 64, 1)', 'rgba(0, 0, 0, 1)'
-        ];
+            'rgba(128,0,0, 1)','rgba(54, 162, 235, 1)','rgba(255, 206, 86, 1)','rgba(75, 192, 192, 1)','rgba(153, 102, 255, 1)',
+            'rgba(255, 159, 64, 1)','rgba(0, 0, 0, 1)','rgba(54,54,54,1)','rgba(25,25,112,1)','rgba(139,69,19,1)',
+            'rgba(139,0,139,1)','rgba(0,100,0,1)','rgba(255,215,0,1)','rgba(0,0,139,1)','rgba(0,100,0,1)','rgba(0,0,0,1)',
+            'rgba(128,0,0,1)','rgba(255,69,0,1)','rgba(107,142,35,1)','rgba(199,21,133,1)','rgba(165,42,42,1)','rgba(0,100,0,1)',
+            'rgba(184,134,11,1)'];
     }
 
     /**
@@ -397,7 +401,7 @@ class CacheCompEscolaController extends Controller
                 ];
 
                 $dataSet[$i] = $item_data_set;
-                if ($contColors == 6) {
+                if ($contColors == 22) {
                     $contColors = 0;
                 } else {
                     $contColors++;
@@ -511,7 +515,7 @@ class CacheCompEscolaController extends Controller
                 ];
 
                 $dataSet[$i] = $item_data_set;
-                if ($contColors == 6) {
+                if ($contColors == 22) {
                     $contColors = 0;
                 } else {
                     $contColors++;

--- a/app/Http/Controllers/cadastros/manutencao/CacheCompMunicipioController.php
+++ b/app/Http/Controllers/cadastros/manutencao/CacheCompMunicipioController.php
@@ -51,10 +51,18 @@ class CacheCompMunicipioController extends Controller
         $this->confPresenca = 1;
         $this->previlegio = [];
         $this->horasCache = 4;
-        $this->backgroundColors = ['rgba(255, 26, 104, 0.2)','rgba(54, 162, 235, 0.2)','rgba(255, 206, 86, 0.2)',
-        'rgba(75, 192, 192, 0.2)','rgba(153, 102, 255, 0.2)','rgba(255, 159, 64, 0.2)','rgba(0, 0, 0, 0.2)'];
-        $this->borderColors = ['rgba(255, 26, 104, 1)','rgba(54, 162, 235, 1)','rgba(255, 206, 86, 1)',
-        'rgba(75, 192, 192, 1)','rgba(153, 102, 255, 1)','rgba(255, 159, 64, 1)','rgba(0, 0, 0, 1)'];
+        $this->backgroundColors = [
+            'rgba(139,0,0, 0.2)','rgba(54, 162, 235, 0.2)','rgba(255, 206, 86, 0.2)','rgba(75, 192, 192, 0.2)','rgba(153, 102, 255, 0.2)',
+            'rgba(255, 159, 64, 0.2)','rgba(0, 0, 0, 0.2)','rgba(220,220,220,0.3)','rgba(0,0,139,0.2)','rgba(160,82,45,0.2)',
+            'rgba(255,0,255,0.2)','rgba(0,128,0,0.2)','rgba(255,255,0,0.2)','rgba(0,0,255,0.2)','rgba(0,255,0,0.2)','rgba(255,255,255,0.2)',
+            'rgba(255,0,0,0.2)','rgba(255,140,0,0.3)','rgba(128,128,0,0.3)','rgba(255,20,147,0.3)','rgba(250,128,114,0.3)','rgba(0,255,0,0.3)',
+            'rgba(255,215,0,0.4)'];
+        $this->borderColors = [
+            'rgba(128,0,0, 1)','rgba(54, 162, 235, 1)','rgba(255, 206, 86, 1)','rgba(75, 192, 192, 1)','rgba(153, 102, 255, 1)',
+            'rgba(255, 159, 64, 1)','rgba(0, 0, 0, 1)','rgba(54,54,54,1)','rgba(25,25,112,1)','rgba(139,69,19,1)',
+            'rgba(139,0,139,1)','rgba(0,100,0,1)','rgba(255,215,0,1)','rgba(0,0,139,1)','rgba(0,100,0,1)','rgba(0,0,0,1)',
+            'rgba(128,0,0,1)','rgba(255,69,0,1)','rgba(107,142,35,1)','rgba(199,21,133,1)','rgba(165,42,42,1)','rgba(0,100,0,1)',
+            'rgba(184,134,11,1)'];
     }
 
     /**
@@ -293,7 +301,7 @@ class CacheCompMunicipioController extends Controller
                 ];   
     
                 $dataSet[$i] = $item_data_set;
-                if($contColors == 6){   
+                if($contColors == 22){   
                     $contColors = 0;
                 } else {
                     $contColors++;
@@ -405,7 +413,7 @@ class CacheCompMunicipioController extends Controller
                 ];   
     
                 $dataSet[$i] = $item_data_set;
-                if($contColors == 6){   
+                if($contColors == 22){   
                     $contColors = 0;
                 } else {
                     $contColors++;

--- a/app/Http/Controllers/comparativo/diretor/DiretorComparativoController.php
+++ b/app/Http/Controllers/comparativo/diretor/DiretorComparativoController.php
@@ -47,10 +47,18 @@ class DiretorComparativoController extends Controller
         $this->confPresenca = 1;
         $this->horasCache = 4;
         $this->previlegio = [];
-        $this->backgroundColors = ['rgba(255, 26, 104, 0.2)','rgba(54, 162, 235, 0.2)','rgba(255, 206, 86, 0.2)',
-        'rgba(75, 192, 192, 0.2)','rgba(153, 102, 255, 0.2)','rgba(255, 159, 64, 0.2)','rgba(0, 0, 0, 0.2)'];
-        $this->borderColors = ['rgba(255, 26, 104, 1)','rgba(54, 162, 235, 1)','rgba(255, 206, 86, 1)',
-        'rgba(75, 192, 192, 1)','rgba(153, 102, 255, 1)','rgba(255, 159, 64, 1)','rgba(0, 0, 0, 1)'];
+        $this->backgroundColors = [
+            'rgba(139,0,0, 0.2)','rgba(54, 162, 235, 0.2)','rgba(255, 206, 86, 0.2)','rgba(75, 192, 192, 0.2)','rgba(153, 102, 255, 0.2)',
+            'rgba(255, 159, 64, 0.2)','rgba(0, 0, 0, 0.2)','rgba(220,220,220,0.3)','rgba(0,0,139,0.2)','rgba(160,82,45,0.2)',
+            'rgba(255,0,255,0.2)','rgba(0,128,0,0.2)','rgba(255,255,0,0.2)','rgba(0,0,255,0.2)','rgba(0,255,0,0.2)','rgba(255,255,255,0.2)',
+            'rgba(255,0,0,0.2)','rgba(255,140,0,0.3)','rgba(128,128,0,0.3)','rgba(255,20,147,0.3)','rgba(250,128,114,0.3)','rgba(0,255,0,0.3)',
+            'rgba(255,215,0,0.4)'];
+        $this->borderColors = [
+            'rgba(128,0,0, 1)','rgba(54, 162, 235, 1)','rgba(255, 206, 86, 1)','rgba(75, 192, 192, 1)','rgba(153, 102, 255, 1)',
+            'rgba(255, 159, 64, 1)','rgba(0, 0, 0, 1)','rgba(54,54,54,1)','rgba(25,25,112,1)','rgba(139,69,19,1)',
+            'rgba(139,0,139,1)','rgba(0,100,0,1)','rgba(255,215,0,1)','rgba(0,0,139,1)','rgba(0,100,0,1)','rgba(0,0,0,1)',
+            'rgba(128,0,0,1)','rgba(255,69,0,1)','rgba(107,142,35,1)','rgba(199,21,133,1)','rgba(165,42,42,1)','rgba(0,100,0,1)',
+            'rgba(184,134,11,1)'];
     }
 
     /**
@@ -534,7 +542,7 @@ class DiretorComparativoController extends Controller
                 ];   
     
                 $dataSet[$i] = $item_data_set;
-                if($contColors == 6){   
+                if($contColors == 22){   
                     $contColors = 0;
                 } else {
                     $contColors++;
@@ -646,7 +654,7 @@ class DiretorComparativoController extends Controller
                 ];   
     
                 $dataSet[$i] = $item_data_set;
-                if($contColors == 6){   
+                if($contColors == 22){   
                     $contColors = 0;
                 } else {
                     $contColors++;

--- a/app/Http/Controllers/comparativo/secretario/SecretarioComparativoController.php
+++ b/app/Http/Controllers/comparativo/secretario/SecretarioComparativoController.php
@@ -51,10 +51,18 @@ class SecretarioComparativoController extends Controller
         $this->objCriterioQuestao = new CriterioQuestao();
         $this->confPresenca = 1;
         $this->previlegio = [];
-        $this->backgroundColors = ['rgba(255, 26, 104, 0.2)','rgba(54, 162, 235, 0.2)','rgba(255, 206, 86, 0.2)',
-        'rgba(75, 192, 192, 0.2)','rgba(153, 102, 255, 0.2)','rgba(255, 159, 64, 0.2)','rgba(0, 0, 0, 0.2)'];
-        $this->borderColors = ['rgba(255, 26, 104, 1)','rgba(54, 162, 235, 1)','rgba(255, 206, 86, 1)',
-        'rgba(75, 192, 192, 1)','rgba(153, 102, 255, 1)','rgba(255, 159, 64, 1)','rgba(0, 0, 0, 1)'];
+        $this->backgroundColors = [
+            'rgba(139,0,0, 0.2)','rgba(54, 162, 235, 0.2)','rgba(255, 206, 86, 0.2)','rgba(75, 192, 192, 0.2)','rgba(153, 102, 255, 0.2)',
+            'rgba(255, 159, 64, 0.2)','rgba(0, 0, 0, 0.2)','rgba(220,220,220,0.3)','rgba(0,0,139,0.2)','rgba(160,82,45,0.2)',
+            'rgba(255,0,255,0.2)','rgba(0,128,0,0.2)','rgba(255,255,0,0.2)','rgba(0,0,255,0.2)','rgba(0,255,0,0.2)','rgba(255,255,255,0.2)',
+            'rgba(255,0,0,0.2)','rgba(255,140,0,0.3)','rgba(128,128,0,0.3)','rgba(255,20,147,0.3)','rgba(250,128,114,0.3)','rgba(0,255,0,0.3)',
+            'rgba(255,215,0,0.4)'];
+        $this->borderColors = [
+            'rgba(128,0,0, 1)','rgba(54, 162, 235, 1)','rgba(255, 206, 86, 1)','rgba(75, 192, 192, 1)','rgba(153, 102, 255, 1)',
+            'rgba(255, 159, 64, 1)','rgba(0, 0, 0, 1)','rgba(54,54,54,1)','rgba(25,25,112,1)','rgba(139,69,19,1)',
+            'rgba(139,0,139,1)','rgba(0,100,0,1)','rgba(255,215,0,1)','rgba(0,0,139,1)','rgba(0,100,0,1)','rgba(0,0,0,1)',
+            'rgba(128,0,0,1)','rgba(255,69,0,1)','rgba(107,142,35,1)','rgba(199,21,133,1)','rgba(165,42,42,1)','rgba(0,100,0,1)',
+            'rgba(184,134,11,1)'];
         $this->horasCache = 4;
     }
 
@@ -475,7 +483,7 @@ class SecretarioComparativoController extends Controller
                 ];   
     
                 $dataSet[$i] = $item_data_set;
-                if($contColors == 6){   
+                if($contColors == 22){   
                     $contColors = 0;
                 } else {
                     $contColors++;
@@ -587,7 +595,7 @@ class SecretarioComparativoController extends Controller
                 ];   
     
                 $dataSet[$i] = $item_data_set;
-                if($contColors == 6){   
+                if($contColors == 22){   
                     $contColors = 0;
                 } else {
                     $contColors++;


### PR DESCRIPTION
 - Foram adicionadas mais cores aos grafico, em um total de 23 cores, de forma que fique mais facil de destinguir os diferentes registros.
 - As cores acima foram adicionada a sessao de comparativo, tanto a nivel de municipio quanto de escola.
 - Foram atualizadas as rotinas de manutencao, no que tange ao carregamento de caches da sessao de comparativo.